### PR TITLE
Expand specs for named references

### DIFF
--- a/spec/integration/named_references_spec.rb
+++ b/spec/integration/named_references_spec.rb
@@ -16,7 +16,22 @@ RSpec.describe "Named references" do
       end
     end
 
-    it "flags duplicate type values"
+    it "flags duplicate type values" do
+      expect(Warning).to receive(:warn).with(/Duplicate types found/).at_least(:once)
+      subject.compile
+    end
+
+    it "generates a type definition using the last named reference" do
+      allow(Warning).to receive(:warn) # patch Warning to clean up rspec output
+      expect(subject.compile.join(";\n")).to include(<<~TYPESCRIPT.strip)
+        export type UUID = string;
+        export type Email = string;
+        export type User = {
+          id: Email
+          email: Email
+        }
+      TYPESCRIPT
+    end
   end
 
   describe "multiple type aliases of the same type with manual alias" do


### PR DESCRIPTION
I wound up adding basic support for named references in `main` to fix #1, but the specs definitely need to be expanded to cover a bunch more use cases. I expect this might lead to additional work to get them all passing too.